### PR TITLE
Fix plugin build and command initialization

### DIFF
--- a/src/main/java/dev/lsdmc/edenCorrections/commands/CommandHandler.java
+++ b/src/main/java/dev/lsdmc/edenCorrections/commands/CommandHandler.java
@@ -48,9 +48,6 @@ public class CommandHandler implements CommandExecutor, TabCompleter {
         plugin.getCommand("corrections").setExecutor(this);
         plugin.getCommand("corrections").setTabCompleter(this);
         
-        plugin.getCommand("edenreload").setExecutor(this);
-        plugin.getCommand("edenreload").setTabCompleter(this);
-        
         // Register contraband commands
         plugin.getCommand("sword").setExecutor(this);
         plugin.getCommand("sword").setTabCompleter(this);
@@ -97,8 +94,6 @@ public class CommandHandler implements CommandExecutor, TabCompleter {
                 return handleJailOfflineCommand(sender, args);
             case "corrections":
                 return handleCorrectionsCommand(sender, args);
-            case "edenreload":
-                return handleReloadCommand(sender, args);
             // Contraband commands
             case "sword":
                 return handleContrabandCommand(sender, "sword", args);
@@ -136,8 +131,6 @@ public class CommandHandler implements CommandExecutor, TabCompleter {
                 return handleJailOfflineTabComplete(sender, args);
             case "corrections":
                 return handleCorrectionsTabComplete(sender, args);
-            case "edenreload":
-                return new ArrayList<>(); // No arguments
             case "sword":
             case "bow":
             case "armor":

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -38,12 +38,6 @@ commands:
     permission: edencorrections.admin
     permission-message: You don't have permission to use this command!
 
-  edenreload:
-    description: Reload EdenCorrections configuration
-    usage: /edenreload
-    permission: edencorrections.admin
-    permission-message: You don't have permission to use this command!
-
   sword:
     description: Request player to drop their sword
     usage: /sword <player>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Remove redundant `edenreload` command to clean up plugin configuration and command handling.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This command was previously removed from use but its initialization and `plugin.yml` entry were not fully cleaned up, leading to unnecessary code and potential confusion.

---
<a href="https://cursor.com/background-agent?bcId=bc-f469ac5b-ec5e-4d27-aac2-e8e650baf70b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f469ac5b-ec5e-4d27-aac2-e8e650baf70b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>